### PR TITLE
Add spatial hash grid for visibility range queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const { createProjectileTickSystem } = require("./server/runtime/projectile-tick
 const { createPlayerTickSystem } = require("./server/runtime/player-tick");
 const { createMobTickSystem } = require("./server/runtime/mob-tick");
 const { createWorldState } = require("./server/runtime/world-state");
+const { createSpatialGrid } = require("./server/runtime/spatial-grid");
 const {
   createAbilityConfigLoader,
   createClassAbilityDefsBroadcaster
@@ -971,6 +972,12 @@ const runtimeBootstrap = createRuntimeBootstrap({
     lootBags,
     VISIBILITY_RANGE,
     inVisibilityRange,
+    spatialGrids: {
+      players: createSpatialGrid(VISIBILITY_RANGE),
+      mobs: createSpatialGrid(VISIBILITY_RANGE),
+      projectiles: createSpatialGrid(VISIBILITY_RANGE),
+      lootBags: createSpatialGrid(VISIBILITY_RANGE)
+    },
     serializePlayer,
     serializeMob,
     buildPlayerSwingEventsForRecipient,

--- a/server/network/state-broadcast.js
+++ b/server/network/state-broadcast.js
@@ -7,7 +7,8 @@ function collectNearbyEntitiesForPlayer(player, deps) {
     inVisibilityRange,
     VISIBILITY_RANGE,
     serializePlayer,
-    serializeMob
+    serializeMob,
+    spatialGrids
   } = deps;
 
   const nearbyPlayers = [];
@@ -17,41 +18,87 @@ function collectNearbyEntitiesForPlayer(player, deps) {
   const nearbyProjectiles = [];
   const nearbyLootBags = [];
 
-  for (const other of players.values()) {
-    if (other.id === player.id) {
-      continue;
+  if (spatialGrids) {
+    const playerIds = spatialGrids.players.queryRect(player.x, player.y, VISIBILITY_RANGE);
+    for (let i = 0; i < playerIds.length; i++) {
+      const id = playerIds[i];
+      if (id === player.id) {
+        continue;
+      }
+      const other = players.get(id);
+      if (other && inVisibilityRange(player, other, VISIBILITY_RANGE)) {
+        nearbyPlayers.push(serializePlayer(other));
+        nearbyPlayerObjects.push(other);
+      }
     }
-    if (inVisibilityRange(player, other, VISIBILITY_RANGE)) {
-      nearbyPlayers.push(serializePlayer(other));
-      nearbyPlayerObjects.push(other);
-    }
-  }
 
-  for (const projectile of projectiles.values()) {
-    if (inVisibilityRange(player, projectile, VISIBILITY_RANGE)) {
-      nearbyProjectiles.push({
-        id: projectile.id,
-        ownerId: projectile.ownerId,
-        abilityId: projectile.abilityId,
-        x: projectile.x,
-        y: projectile.y
-      });
+    const projectileIds = spatialGrids.projectiles.queryRect(player.x, player.y, VISIBILITY_RANGE);
+    for (let i = 0; i < projectileIds.length; i++) {
+      const projectile = projectiles.get(projectileIds[i]);
+      if (projectile && inVisibilityRange(player, projectile, VISIBILITY_RANGE)) {
+        nearbyProjectiles.push({
+          id: projectile.id,
+          ownerId: projectile.ownerId,
+          abilityId: projectile.abilityId,
+          x: projectile.x,
+          y: projectile.y
+        });
+      }
     }
-  }
 
-  for (const mob of mobs.values()) {
-    if (!mob.alive) {
-      continue;
+    const mobIds = spatialGrids.mobs.queryRect(player.x, player.y, VISIBILITY_RANGE);
+    for (let i = 0; i < mobIds.length; i++) {
+      const mob = mobs.get(mobIds[i]);
+      if (mob && mob.alive && inVisibilityRange(player, mob, VISIBILITY_RANGE)) {
+        nearbyMobs.push(serializeMob(mob));
+        nearbyMobObjects.push(mob);
+      }
     }
-    if (inVisibilityRange(player, mob, VISIBILITY_RANGE)) {
-      nearbyMobs.push(serializeMob(mob));
-      nearbyMobObjects.push(mob);
-    }
-  }
 
-  for (const bag of lootBags.values()) {
-    if (inVisibilityRange(player, bag, VISIBILITY_RANGE)) {
-      nearbyLootBags.push(bag);
+    const bagIds = spatialGrids.lootBags.queryRect(player.x, player.y, VISIBILITY_RANGE);
+    for (let i = 0; i < bagIds.length; i++) {
+      const bag = lootBags.get(bagIds[i]);
+      if (bag && inVisibilityRange(player, bag, VISIBILITY_RANGE)) {
+        nearbyLootBags.push(bag);
+      }
+    }
+  } else {
+    for (const other of players.values()) {
+      if (other.id === player.id) {
+        continue;
+      }
+      if (inVisibilityRange(player, other, VISIBILITY_RANGE)) {
+        nearbyPlayers.push(serializePlayer(other));
+        nearbyPlayerObjects.push(other);
+      }
+    }
+
+    for (const projectile of projectiles.values()) {
+      if (inVisibilityRange(player, projectile, VISIBILITY_RANGE)) {
+        nearbyProjectiles.push({
+          id: projectile.id,
+          ownerId: projectile.ownerId,
+          abilityId: projectile.abilityId,
+          x: projectile.x,
+          y: projectile.y
+        });
+      }
+    }
+
+    for (const mob of mobs.values()) {
+      if (!mob.alive) {
+        continue;
+      }
+      if (inVisibilityRange(player, mob, VISIBILITY_RANGE)) {
+        nearbyMobs.push(serializeMob(mob));
+        nearbyMobObjects.push(mob);
+      }
+    }
+
+    for (const bag of lootBags.values()) {
+      if (inVisibilityRange(player, bag, VISIBILITY_RANGE)) {
+        nearbyLootBags.push(bag);
+      }
     }
   }
 
@@ -245,10 +292,25 @@ function clearPendingWorldEvents(deps, options = {}) {
   }
 }
 
+function rebuildSpatialGrids(deps) {
+  const { spatialGrids, players, mobs, projectiles, lootBags } = deps;
+  if (!spatialGrids) {
+    return;
+  }
+  spatialGrids.players.rebuildFromMap(players);
+  spatialGrids.mobs.rebuildFromMap(mobs, function (mob) {
+    return mob.alive;
+  });
+  spatialGrids.projectiles.rebuildFromMap(projectiles);
+  spatialGrids.lootBags.rebuildFromMap(lootBags);
+}
+
 function broadcastStateToPlayers(deps, now = Date.now(), options = {}) {
   const { players, buildEntityUpdatePacket, sendBinary } = deps;
   const sendCosmeticBursts = options.sendCosmeticBursts !== false;
   const sendDamageBursts = options.sendDamageBursts !== false;
+
+  rebuildSpatialGrids(deps);
 
   for (const player of players.values()) {
     if (!player || !player.ws) {

--- a/server/runtime/spatial-grid.js
+++ b/server/runtime/spatial-grid.js
@@ -1,0 +1,131 @@
+/**
+ * Spatial hash grid for efficient range queries on a 2D map.
+ *
+ * Entities are bucketed into square cells.  A range query only inspects the
+ * cells that overlap the query rectangle, turning O(N) full-scan visibility
+ * checks into O(k) where k is the number of nearby entities.
+ */
+
+function createSpatialGrid(cellSize) {
+  const cs = Math.max(1, Number(cellSize) || 1);
+  /** @type {Map<string, Set<string|number>>} */
+  const cells = new Map();
+  /** @type {Map<string|number, string>} cellKey by entity id */
+  const entityCell = new Map();
+
+  function cellKey(x, y) {
+    return Math.floor(x / cs) + "," + Math.floor(y / cs);
+  }
+
+  function insert(id, x, y) {
+    const key = cellKey(x, y);
+    entityCell.set(id, key);
+    let bucket = cells.get(key);
+    if (!bucket) {
+      bucket = new Set();
+      cells.set(key, bucket);
+    }
+    bucket.add(id);
+  }
+
+  function remove(id) {
+    const key = entityCell.get(id);
+    if (key === undefined) {
+      return;
+    }
+    entityCell.delete(id);
+    const bucket = cells.get(key);
+    if (bucket) {
+      bucket.delete(id);
+      if (bucket.size === 0) {
+        cells.delete(key);
+      }
+    }
+  }
+
+  function update(id, x, y) {
+    const newKey = cellKey(x, y);
+    const oldKey = entityCell.get(id);
+    if (oldKey === newKey) {
+      return;
+    }
+    if (oldKey !== undefined) {
+      const oldBucket = cells.get(oldKey);
+      if (oldBucket) {
+        oldBucket.delete(id);
+        if (oldBucket.size === 0) {
+          cells.delete(oldKey);
+        }
+      }
+    }
+    entityCell.set(id, newKey);
+    let bucket = cells.get(newKey);
+    if (!bucket) {
+      bucket = new Set();
+      cells.set(newKey, bucket);
+    }
+    bucket.add(id);
+  }
+
+  /**
+   * Return all entity IDs whose cell overlaps the axis-aligned box
+   * centred on (cx, cy) with half-width `range`.
+   *
+   * This intentionally returns a superset — the caller still does the
+   * precise distance / box check per entity, but the candidate set is
+   * drastically smaller than iterating everything.
+   */
+  function queryRect(cx, cy, range) {
+    const minCellX = Math.floor((cx - range) / cs);
+    const maxCellX = Math.floor((cx + range) / cs);
+    const minCellY = Math.floor((cy - range) / cs);
+    const maxCellY = Math.floor((cy + range) / cs);
+
+    const result = [];
+    for (let gx = minCellX; gx <= maxCellX; gx++) {
+      for (let gy = minCellY; gy <= maxCellY; gy++) {
+        const bucket = cells.get(gx + "," + gy);
+        if (bucket) {
+          for (const id of bucket) {
+            result.push(id);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Rebuild the entire grid from a Map of entities.
+   * Each entity must have numeric `x` and `y` properties.
+   * An optional `filterFn(entity)` can skip entries (e.g. dead mobs).
+   */
+  function rebuildFromMap(entityMap, filterFn) {
+    cells.clear();
+    entityCell.clear();
+    for (const entity of entityMap.values()) {
+      if (filterFn && !filterFn(entity)) {
+        continue;
+      }
+      insert(entity.id, entity.x, entity.y);
+    }
+  }
+
+  function clear() {
+    cells.clear();
+    entityCell.clear();
+  }
+
+  return {
+    insert,
+    remove,
+    update,
+    queryRect,
+    rebuildFromMap,
+    clear
+  };
+}
+
+module.exports = {
+  createSpatialGrid
+};


### PR DESCRIPTION
# Add spatial hash grid for visibility range queries

## Summary

Replaces the O(P × N) full-scan visibility checks in `broadcastStateToPlayers` with a spatial hash grid that narrows candidates to nearby cells before the precise `inVisibilityRange` check.

**Before:** For each connected player, every player/mob/projectile/loot bag was iterated to check visibility — O(P × (P + M + J + B)) per tick.

**After:** A spatial hash grid (cell size = `VISIBILITY_RANGE`) is rebuilt once per broadcast tick in O(N), then each player queries only the ~9 overlapping cells — reducing per-player work to O(k) where k is nearby entities.

### What changed
- **New file `server/runtime/spatial-grid.js`**: Cell-based spatial hash with `insert`, `remove`, `update`, `queryRect`, and `rebuildFromMap` methods.
- **`server/network/state-broadcast.js`**: `collectNearbyEntitiesForPlayer` uses grid queries when `spatialGrids` is present; falls back to original full-scan otherwise. `rebuildSpatialGrids` is called at the top of each broadcast tick.
- **`server.js`**: Creates 4 spatial grids (players, mobs, projectiles, lootBags) and wires them into `stateBroadcastDeps`.

### What is NOT changed
- Pending event arrays (damage, explosions, projectile hits, mob deaths) still use linear scan — these are small ephemeral arrays flushed every tick.
- `area-effect-events.js` still iterates `activeAreaEffects` with `inVisibilityRange`.
- The precise `inVisibilityRange` check is still applied after the grid narrows candidates, so **visible entity sets should be identical** to before.

## Review & Testing Checklist for Human
- [ ] **Verify `queryRect` cell math covers the full visibility box** — with `cellSize = VISIBILITY_RANGE`, a query with `range = VISIBILITY_RANGE` should check a 3×3 block of cells. Confirm no off-by-one at cell boundaries (e.g. entity at exactly `x = cellSize * N`).
- [ ] **Verify behavioral equivalence in-game** — join with 2+ players and bots, move around the map, confirm all entities (players, mobs, projectiles, loot bags) appear/disappear at the same distances as before. The easiest way: temporarily log counts from both paths and compare.
- [ ] **Confirm grid rebuild cost is acceptable at scale** — grids are rebuilt from scratch every tick. With hundreds of mobs + projectiles this should still be cheap, but worth profiling if entity counts grow significantly.
- [ ] **Check that mixed ID types work correctly** — `world-state.js` returns String IDs for players/lootBags/areaEffects but Number IDs for mobs/projectiles. The grid stores whatever `entity.id` is, and `Map.get()` uses the same key, so this should be safe — but edge cases with `===` comparison in the grid (e.g. `id === player.id` on line 25) could bite if types diverge.

### Notes
- The `insert`/`remove`/`update` methods on the grid are exported but currently unused at runtime (only `rebuildFromMap` + `queryRect` are called). They're available for future incremental-update optimization.
- No unit tests are included (the existing repo has near-zero test coverage). The grid was verified with a manual node script.

Link to Devin Session: https://app.devin.ai/sessions/52805ba8de3e49469213a8cf06b9599c
Requested by: @desdae